### PR TITLE
add shadow > both() and unified the id names

### DIFF
--- a/elements.less
+++ b/elements.less
@@ -126,6 +126,11 @@
     -o-text-shadow: @arguments;
     -khtml-text-shadow: @arguments;
  }
+ .none() {
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+ }
 }
 
 #transform {


### PR DESCRIPTION
hi,

i add shadow > both() to add inner and outer shadows.

and also changed
gradients > gradient
shadows > shadow
borders > border

to unify the names, because "transition" is also singular, and it feels more right when you add to a rule
    #border > .rounded(2px);

you could also ask the real origin to pull your changes.
i personally like the way of using ids an then the type.

fabian
